### PR TITLE
Bug nagios downtime issue41

### DIFF
--- a/katprep/clients/NagiosCGIClient.py
+++ b/katprep/clients/NagiosCGIClient.py
@@ -102,6 +102,9 @@ class NagiosCGIClient:
 .. seealso:: __api_post()
         """
         #send request to API
+        self.LOGGER.debug(
+            "%s request to URL '%s', payload='%s'", method, sub_url, payload
+        )
         try:
             if method.lower() not in ["get", "post"]:
                 #going home
@@ -218,7 +221,7 @@ class NagiosCGIClient:
                     'btnSubmit': 'Commit'}
             else:
                 payload = {
-                    'cmd_typ': '55', 'cmd_mod': '2', 'host': object_name,
+                    'cmd_typ': '86', 'cmd_mod': '2', 'host': object_name,
                     'com_data': comment, 'trigger': '0', 'fixed': '1',
                     'hours': hours, 'minutes': '0', 'start_time': current_time,
                     'end_time': end_time, 'btnSubmit': 'Commit',

--- a/katprep/clients/NagiosCGIClient.py
+++ b/katprep/clients/NagiosCGIClient.py
@@ -128,8 +128,8 @@ class NagiosCGIClient:
                     "{}{}".format(self.url, sub_url),
                     headers=self.HEADERS, verify=self.verify
                     )
-
-            self.LOGGER.debug("HTML output: %s", result.text)
+            #this really breaks shit
+            #self.LOGGER.debug("HTML output: %s", result.text)
             if "error" in result.text.lower():
                 raise SessionException("Unable to authenticate")
             if result.status_code != 200:

--- a/katprep/clients/NagiosCGIClient.py
+++ b/katprep/clients/NagiosCGIClient.py
@@ -51,7 +51,7 @@ class NagiosCGIClient:
     """
     str: Nagios/Icinga URL
     """
-    OBSOLETE = False
+    obsolete = False
     """
     bool: Nagios system
     """
@@ -106,7 +106,7 @@ class NagiosCGIClient:
         :param flag: boolean whether Nagios system
         :type flag: bool
         """
-        self.OBSOLETE = flag
+        self.obsolete = flag
 
     def connect(self):
         """
@@ -260,7 +260,7 @@ class NagiosCGIClient:
                 }
         else:
             if remove_downtime:
-                if self.OBSOLETE:
+                if self.obsolete:
                     #you really like old stuff don't you
                     raise UnsupportedRequest(
                         "Unscheduling downtimes is not supported with Nagios!"
@@ -278,13 +278,13 @@ class NagiosCGIClient:
                     'end_time': end_time, 'btnSubmit': 'Commit',
                     'com_author': self.username, 'childoptions': '0'
                 }
-                if self.OBSOLETE:
+                if self.obsolete:
                     #we need to make two calls as legacy hurts twice
                     payload[1] = payload[0].copy()
                     payload[1]['cmd_typ'] = '55'
 
         #send POST
-        result = ""
+        result = None
         for req in payload:
             result = self.__api_post("/cgi-bin/cmd.cgi", payload[req])
         return result
@@ -421,7 +421,7 @@ class NagiosCGIClient:
         }
         for code in codes:
             if code in state[:8].lower():
-                return codes[code] 
+                return codes[code]
 
 
 
@@ -477,15 +477,7 @@ class NagiosCGIClient:
                     "state": self.__get_state(hits[counter+1])
                 })
                 counter = counter + 2
-            print services
-        #if len(hits)%2 == 0:
-        #    services = []
-        #    counter = 0
-        #    while counter < len(hits):
-        #        services.append({hits[counter] : hits[counter+1]})
-        #        counter = counter + 2
-        #    return services
-        #return hits
+            return services
 
 
 

--- a/katprep/maintenance.py
+++ b/katprep/maintenance.py
@@ -473,6 +473,9 @@ def parse_options(args=None):
     #snapshot reports
     gen_opts.add_argument('report', metavar='FILE', nargs=1, \
     help='A snapshot report', type=is_valid_report)
+    #--insecure
+    gen_opts.add_argument("--insecure", dest="ssl_verify", default=True, \
+    action="store_false", help="Disables SSL verification (default: no)")
 
     #FOREMAN ARGUMENTS
     #-s / --foreman-server
@@ -488,9 +491,6 @@ def parse_options(args=None):
     fman_opts.add_argument("-R", "--no-reboot", dest="foreman_no_reboot", \
     default=True, action="store_false", help="suppresses rebooting the " \
     "system under any circumstances (default: no)")
-    #--insecure
-    fman_opts.add_argument("--insecure", dest="ssl_verify", default=True, \
-    action="store_false", help="Disables SSL verification (default: no)")
 
     #VIRTUALIZATION ARGUMENTS
     #--virt-uri
@@ -677,7 +677,8 @@ def main(options, args):
                 host_params["katprep_mon_type"] == "nagios":
                 #Yet another legacy installation
                 MON_CLIENTS[host] = NagiosCGIClient(
-                    LOG_LEVEL, host, mon_user, mon_pass
+                    LOG_LEVEL, host, mon_user, mon_pass, \
+                    verify=options.ssl_verify
                 )
             elif "katprep_mon_type" in host_params:
                 #Icinga 2, yay!

--- a/katprep/populate.py
+++ b/katprep/populate.py
@@ -207,6 +207,9 @@ def parse_options(args=None):
     #--ip-filter
     gen_opts.add_argument("--ipv6-only", dest="ipv6_only", default=False, \
     action="store_true", help="Filters for IPv6-only addresses (default: no)")
+    #--insecure
+    gen_opts.add_argument("--insecure", dest="ssl_verify", default=True, \
+    action="store_false", help="Disables SSL verification (default: no)")
 
     #FOREMAN ARGUMENTS
     #-s / --foreman-server
@@ -217,9 +220,6 @@ def parse_options(args=None):
     fman_opts.add_argument("-u", "--update", dest="foreman_update", \
     action="store_true", default=False, help="Updates pre-existing host " \
     "parameters (default: no)")
-    #--insecure
-    fman_opts.add_argument("--insecure", dest="ssl_verify", default=True, \
-    action="store_false", help="Disables SSL verification (default: no)")
 
     #VIRTUALIZATION ARGUMENTS
     virt_opts.add_argument("--virt-uri", dest="virt_uri", \
@@ -309,7 +309,8 @@ def main(options, args):
         if options.mon_type == "nagios":
             #Yet another legacy installation
             MON_CLIENT = NagiosCGIClient(
-                LOG_LEVEL, options.mon_url, mon_user, mon_pass
+                LOG_LEVEL, options.mon_url, mon_user, mon_pass, \
+                verify=options.ssl_verify
             )
         else:
             #Icinga 2, yay!


### PR DESCRIPTION
- fixed a bug where downtime was only assigned to hosts excluding their services
- implemented auto-detection of Nagios in order to prohibit unsupported calls (*unscheduling downtime*)
- added a parameter for SSL verification
- fixed webs-crap-ping for Nagios
- adjusted `get_services()` in order to work along with `katprep_populate`
