### PR TITLE
Bug errata reboot issue40

### DIFF
--- a/katprep/maintenance.py
+++ b/katprep/maintenance.py
@@ -251,33 +251,15 @@ def execute(options, args):
             errata_reboot = [x["reboot_suggested"] for x in REPORT[host]["errata"]]
             if options.foreman_reboot or \
                 (True in errata_reboot and not options.foreman_no_reboot):
-                #trigger workaround if VM
-                if get_host_param_from_report(REPORT, host, "katprep_virt") \
-                    not in ["", None]:
-                    #use customized VM name if applicable
-                    if get_host_param_from_report(REPORT, host, "katprep_virt_name") \
-                        not in ["", None]:
-                        vm_name = get_host_param_from_report(
-                            REPORT, host, "katprep_virt_name"
-                        )
-                    else:
-                        vm_name = host
-                    #reboot VM
-                    if options.generic_dry_run:
-                        LOGGER.info("Host '%s' --> reboot VM", host)
-                    else:
-                        VIRT_CLIENTS[get_host_param_from_report(REPORT, host, "katprep_virt")].restart_vm(vm_name)
-                else:
-                    #physical host
-                    if options.generic_dry_run:
-                        LOGGER.info("Host '%s' --> reboot host", host)
-                    else:
-                        SAT_CLIENT.api_put(
-                            "/hosts/{}/power".format(
-                                SAT_CLIENT.get_id_by_name(host, "host")
-                            ),
-                            json.dumps({"power_action": "soft"})
-                        )
+               if options.generic_dry_run:
+                    LOGGER.info("Host '%s' --> reboot host", host)
+               else:
+                    SAT_CLIENT.api_put(
+                        "/hosts/{}/power".format(
+                            SAT_CLIENT.get_id_by_name(host, "host")
+                        ),
+                        json.dumps({"power_action": "soft"})
+                    )
 
     except ValueError as err:
         LOGGER.error("Error maintaining host: '%s'", err)

--- a/katprep/maintenance.py
+++ b/katprep/maintenance.py
@@ -12,8 +12,8 @@ import logging
 import json
 import time
 import os
-import yaml
 import getpass
+import yaml
 from . import is_valid_report, get_json, get_credentials, \
 get_required_hosts_by_report, get_host_params_by_report
 from .clients.ForemanAPIClient import ForemanAPIClient
@@ -251,9 +251,9 @@ def execute(options, args):
             errata_reboot = [x["reboot_suggested"] for x in REPORT[host]["errata"]]
             if options.foreman_reboot or \
                 (True in errata_reboot and not options.foreman_no_reboot):
-               if options.generic_dry_run:
+                if options.generic_dry_run:
                     LOGGER.info("Host '%s' --> reboot host", host)
-               else:
+                else:
                     SAT_CLIENT.api_put(
                         "/hosts/{}/power".format(
                             SAT_CLIENT.get_id_by_name(host, "host")


### PR DESCRIPTION
Fixed an issue where VM reboots where triggered while errata installation was running (see also issue #40):
- reverted workaround from #4 as the functionality is now covered by the Foreman API
- cleaned-up code

The code was tested successfully on Foreman 1.17.1 and Katello 3.6. When using Red Hat Satellite, version 6.3 is needed.