### PR TITLE
Changed task status error to info message

### DIFF
--- a/katprep/maintenance.py
+++ b/katprep/maintenance.py
@@ -504,7 +504,7 @@ def status(options, args):
                                     task, host
                                 )
                             elif result["result"].lower() == "error":
-                                LOGGER.error(
+                                LOGGER.info(
                                     "%s task for host '%s' FAILED!",
                                     task, host
                                 )


### PR DESCRIPTION
Changed ``error()`` to ``info()``, see also issue #75.