### PR TITLE
Harder requirements

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest
-pytest-cov
+pytest < 5.0  # Pytest 5 dropped support for Python 2.7
+pytest-cov < 2.6  # pytest-cov 2.6 dropped support for Python < 3.4
 mock
 codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lxml
+lxml < 4.4  # Support for Python 3.4 was removed in 4.4.0
 pyvmomi
 pyyaml
 fernet


### PR DESCRIPTION
katprept is still running with Python 2.7 and 3.4.

We need to be a little more specific about our requirements here since a lot of libs are dropping support for Python 2 and old 3.x versions.