### PR TITLE
Strip leading and trailing whitespace from credentials

### DIFF
--- a/katprep/AuthContainer.py
+++ b/katprep/AuthContainer.py
@@ -148,6 +148,7 @@ class AuthContainer:
                     type(password)
                 )
             )
+        password = password.strip()
 
         hostname = self.cut_hostname(hostname)
 
@@ -161,7 +162,7 @@ class AuthContainer:
                 raise ContainerException("Invalid password specified!")
 
         self.__credentials[hostname] = {
-            "username": username,
+            "username": username.strip(),
             "password": password,
         }
 

--- a/tests/test_AuthContainer.py
+++ b/tests/test_AuthContainer.py
@@ -2,6 +2,7 @@ import logging
 import os
 import os.path
 from collections import namedtuple
+from random import choice
 
 import pytest
 from katprep.AuthContainer import AuthContainer, ContainerException
@@ -98,6 +99,27 @@ def test_removing_credential(container, hostname, username, password):
 
     container.remove_credentials(hostname)
     assert None == container.get_credential(hostname)
+
+
+def test_stripping_whitespace(container, hostname, username, password):
+    whitespace = (" ", "\t", "\n")
+
+    def add_whitespace(string):
+        return choice(whitespace) + string + choice(whitespace)
+
+    new_user = add_whitespace(username)
+    new_pw = add_whitespace(password)
+
+    container.add_credentials(hostname, new_user, new_pw)
+
+    credentials = container.get_credential(hostname)
+
+    assert not credentials.username.endswith(whitespace)
+    assert not credentials.username.startswith(whitespace)
+    assert credentials.username == username
+    assert not credentials.password.startswith(whitespace)
+    assert not credentials.password.endswith(whitespace)
+    assert credentials.password == password
 
 
 @pytest.fixture(


### PR DESCRIPTION
As found out during our testing session it makes sense to strip leading and trailing whitespace from the credentials.