### PR TITLE
Refactor check for validate uri

### DIFF
--- a/katprep/virtualization/libvirt.py
+++ b/katprep/virtualization/libvirt.py
@@ -62,18 +62,17 @@ class LibvirtClient(BaseConnector, SnapshotManager, PowerManager):
         :param uri: a libvirt URI
         :type uri: str
         """
+        if "://" not in uri:
+            return False
+
         prefixes = {
             "lxc", "qemu", "xen", "hyperv", "vbox", "openvz", "uml", "phyp",
             "vz", "bhyve", "esx", "vpx", "vmwareplayer", "vmwarews",
             "vmwarefusion"
         }
-        #check whether a valid prefix was found
-        for prefix in prefixes:
-            if prefix in uri and "://" in uri:
-                return True
-        return False
 
-
+        # check whether a valid prefix was found
+        return any(uri.startswith(prefix) for prefix in prefixes)
 
     def _connect(self):
         """This function establishes a connection to the hypervisor."""

--- a/tests/test_LibvirtClient.py
+++ b/tests/test_LibvirtClient.py
@@ -93,3 +93,13 @@ def test_snapshot_handling(virtClient, config, snapshot_name):
             print(err)
     finally:
         virtClient.remove_snapshot(host, snapshot_name)
+
+@pytest.mark.parametrize("uri", [
+    "openvz://some.host.tld",
+    pytest.param("invalid://openvz",
+                 marks=pytest.mark.xfail(reason="Invalid protocol"))
+])
+def test_uri_validation(uri):
+    LibvirtClient = pytest.importorskip("katprep.virtualization.libvirt.LibvirtClient")
+
+    assert LibvirtClient.validate_uri("https://openvz/")


### PR DESCRIPTION
The current implementation could be tricked into accepting invalid URIs by a matching hostname. This fixes this.